### PR TITLE
Guarantee RxViewModel's state updates on the main thread

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,24 +1,6 @@
 {
   "pins" : [
     {
-      "identity" : "combine-schedulers",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/combine-schedulers",
-      "state" : {
-        "revision" : "9dc9cbe4bc45c65164fa653a563d8d8db61b09bb",
-        "version" : "1.0.0"
-      }
-    },
-    {
-      "identity" : "swift-concurrency-extras",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
-      "state" : {
-        "revision" : "bb5059bde9022d69ac516803f4f227d8ac967f71",
-        "version" : "1.1.0"
-      }
-    },
-    {
       "identity" : "swift-custom-dump",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,6 @@ let package = Package(
         .imrx,
     ],
     dependencies: [
-        .combineSchedulers,
         .customDump,
     ],
     targets: [
@@ -34,16 +33,12 @@ private extension Product {
 private extension Target {
     
     static let imrx = target(
-        name: .imrx,
-        dependencies: [
-            .combineSchedulers,
-        ]
+        name: .imrx
     )
     
     static let imrxTests = testTarget(
         name: .imrxTests,
         dependencies: [
-            .combineSchedulers,
             .customDump,
             .imrx,
         ]

--- a/Sources/IMRx/EffectHandler.swift
+++ b/Sources/IMRx/EffectHandler.swift
@@ -10,7 +10,7 @@ public protocol EffectHandler<Event, Effect> {
     associatedtype Event: Equatable
     associatedtype Effect: Equatable
     
-    typealias Dispatch = (Event) -> Void
+    typealias Dispatch = @MainActor (Event) -> Void
     
     func handleEffect(
         _ effect: Effect, 

--- a/Sources/IMRx/Reducer.swift
+++ b/Sources/IMRx/Reducer.swift
@@ -11,11 +11,13 @@ public protocol Reducer<State, Event, Effect> {
     associatedtype Event
     associatedtype Effect
     
+    @MainActor
     func reduce(_ state: State,_ event: Event) -> (State, Effect?)
 }
 
 public extension Reducer {
     
+    @MainActor
     func reduce(
         _ state: inout State,
         _ event: Event

--- a/Sources/IMRx/RxViewModel+ext.swift
+++ b/Sources/IMRx/RxViewModel+ext.swift
@@ -5,7 +5,6 @@
 //  Created by Igor Malyarov on 20.01.2024.
 //
 
-import CombineSchedulers
 import Foundation
 
 public extension RxViewModel where State: Equatable {
@@ -13,15 +12,13 @@ public extension RxViewModel where State: Equatable {
     convenience init(
         initialState: State,
         reducer: any Reducer<State, Event, Effect>,
-        effectHandler: some EffectHandler<Event, Effect>,
-        scheduler: AnySchedulerOf<DispatchQueue> = .main
+        effectHandler: some EffectHandler<Event, Effect>
     ) {
         
         self.init(
             initialState: initialState,
             reduce: reducer.reduce(_:_:),
-            handleEffect: effectHandler.handleEffect(_:_:),
-            scheduler: scheduler
+            handleEffect: effectHandler.handleEffect(_:_:)
         )
     }
 }

--- a/Sources/IMRx/RxViewModel.swift
+++ b/Sources/IMRx/RxViewModel.swift
@@ -6,7 +6,6 @@
 //
 
 import Combine
-import CombineSchedulers
 import Foundation
 
 public final class RxViewModel<State, Event, Effect>: ObservableObject {
@@ -22,8 +21,7 @@ public final class RxViewModel<State, Event, Effect>: ObservableObject {
         initialState: State,
         reduce: @escaping Reduce,
         handleEffect: @escaping HandleEffect,
-        predicate: @escaping (State, State) -> Bool,
-        scheduler: AnySchedulerOf<DispatchQueue> = .main
+        predicate: @escaping (State, State) -> Bool
     ) {
         self.state = initialState
         self.reduce = reduce
@@ -31,7 +29,6 @@ public final class RxViewModel<State, Event, Effect>: ObservableObject {
         
         stateSubject
             .removeDuplicates(by: predicate)
-            .receive(on: scheduler)
             .assign(to: &$state)
     }
 }
@@ -65,16 +62,14 @@ public extension RxViewModel where State: Equatable {
     convenience init(
         initialState: State,
         reduce: @escaping Reduce,
-        handleEffect: @escaping HandleEffect,
-        scheduler: AnySchedulerOf<DispatchQueue> = .main
+        handleEffect: @escaping HandleEffect
     ) {
         
         self.init(
             initialState: initialState,
             reduce: reduce,
             handleEffect: handleEffect,
-            predicate: ==,
-            scheduler: scheduler
+            predicate: ==
         )
     }
 }

--- a/Sources/IMRx/RxViewModel.swift
+++ b/Sources/IMRx/RxViewModel.swift
@@ -38,6 +38,7 @@ public final class RxViewModel<State, Event, Effect>: ObservableObject {
 
 public extension RxViewModel {
     
+    @MainActor
     func event(_ event: Event) {
         
         let (state, effect) = reduce(state, event)
@@ -55,8 +56,8 @@ public extension RxViewModel {
 
 public extension RxViewModel {
     
-    typealias Reduce = (State, Event) -> (State, Effect?)
-    typealias HandleEffect = (Effect, @escaping (Event) -> Void) -> Void
+    typealias Reduce = @MainActor (State, Event) -> (State, Effect?)
+    typealias HandleEffect = (Effect, @MainActor @escaping (Event) -> Void) -> Void
 }
 
 public extension RxViewModel where State: Equatable {

--- a/Tests/IMRxTests/Helpers/EffectHandlerSpy.swift
+++ b/Tests/IMRxTests/Helpers/EffectHandlerSpy.swift
@@ -22,6 +22,7 @@ where Event: Equatable,
         messages.append((effect, dispatch))
     }
     
+    @MainActor
     func complete(
         with event: Event,
         at index: Int = 0
@@ -29,6 +30,6 @@ where Event: Equatable,
         messages[index].dispatch(event)
     }
     
-    typealias Dispatch = (Event) -> Void
+    typealias Dispatch = @MainActor (Event) -> Void
     typealias Message = (effect: Effect, dispatch: Dispatch)
 }

--- a/Tests/IMRxTests/RxViewModelTests.swift
+++ b/Tests/IMRxTests/RxViewModelTests.swift
@@ -140,8 +140,7 @@ final class RxViewModelTests: XCTestCase {
         let sut = SUT(
             initialState: initialState,
             reducer: reducer,
-            effectHandler: effectHandler,
-            scheduler: .immediate
+            effectHandler: effectHandler
         )
         
         trackForMemoryLeaks(sut, file: file, line: line)

--- a/Tests/IMRxTests/RxViewModelTests.swift
+++ b/Tests/IMRxTests/RxViewModelTests.swift
@@ -18,6 +18,7 @@ final class RxViewModelTests: XCTestCase {
         XCTAssertNoDiff(effectHandler.callCount, 0)
     }
     
+    @MainActor
     func test_event_shouldCallReducerWithGivenStateAndEvent() {
         
         let initialState = makeState()
@@ -33,6 +34,7 @@ final class RxViewModelTests: XCTestCase {
         XCTAssertNoDiff(reducer.messages.map(\.event), [event])
     }
     
+    @MainActor
     func test_event_shouldNotCallEffectHandlerOnNilEffect() {
         
         let effect: Effect? = nil
@@ -45,6 +47,7 @@ final class RxViewModelTests: XCTestCase {
         XCTAssertNoDiff(effectHandler.callCount, 0)
     }
     
+    @MainActor
     func test_event_shouldCallEffectHandlerOnNonNilEffect() {
         
         let effect: Effect = .load
@@ -57,6 +60,7 @@ final class RxViewModelTests: XCTestCase {
         XCTAssertNoDiff(effectHandler.messages.map(\.effect), [effect])
     }
     
+    @MainActor
     func test_event_shouldCallReducerTwiceOnEffect() {
         
         let (sut, reducer, effectHandler) = makeSUT(
@@ -71,6 +75,7 @@ final class RxViewModelTests: XCTestCase {
         XCTAssertNoDiff(reducer.callCount, 2)
     }
     
+    @MainActor
     func test_event_shouldReducerWithGivenStateAndEvent() {
         
         let initialState = makeState()
@@ -95,6 +100,7 @@ final class RxViewModelTests: XCTestCase {
         ])
     }
     
+    @MainActor
     func test_event_shouldDeliverStateValues() {
         
         let initialState = makeState()


### PR DESCRIPTION
Since the property `state` of RxViewModel declared as with `@Published` property wrapper, it should be updated in the main thread. We can use `@MainActor` attribute to guarantee code execution on the main actor thread. Also we can eliminate scheduler, because it don't need anymore, and CombineSchedulers library dependency.