### PR TITLE
add ObservableModel in new IMRxObservation module

### DIFF
--- a/.swiftpm/IMRxObservation.xctestplan
+++ b/.swiftpm/IMRxObservation.xctestplan
@@ -1,7 +1,7 @@
 {
   "configurations" : [
     {
-      "id" : "56D8D73C-D370-48E5-9D86-9E9787029514",
+      "id" : "D727A491-F2B5-42B8-B116-150C99328ADC",
       "name" : "Test Scheme Action",
       "options" : {
 
@@ -9,28 +9,15 @@
     }
   ],
   "defaultOptions" : {
+    "performanceAntipatternCheckerEnabled" : true,
     "testExecutionOrdering" : "random"
   },
   "testTargets" : [
     {
       "target" : {
         "containerPath" : "container:",
-        "identifier" : "IMToolsTests",
-        "name" : "IMToolsTests"
-      }
-    },
-    {
-      "target" : {
-        "containerPath" : "container:",
         "identifier" : "IMRxObservationTests",
         "name" : "IMRxObservationTests"
-      }
-    },
-    {
-      "target" : {
-        "containerPath" : "container:",
-        "identifier" : "IMRxTests",
-        "name" : "IMRxTests"
       }
     }
   ],

--- a/.swiftpm/xcode/xcshareddata/xcschemes/IMRxObservation.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/IMRxObservation.xcscheme
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2630"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "IMRxObservation"
+               BuildableName = "IMRxObservation"
+               BlueprintName = "IMRxObservation"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:.swiftpm/IMRxObservation.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "IMRxObservation"
+            BuildableName = "IMRxObservation"
+            BlueprintName = "IMRxObservation"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/swift-imrx-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/swift-imrx-Package.xcscheme
@@ -35,6 +35,20 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "IMRxObservation"
+               BuildableName = "IMRxObservation"
+               BlueprintName = "IMRxObservation"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -66,6 +80,16 @@
                BlueprintIdentifier = "IMToolsTests"
                BuildableName = "IMToolsTests"
                BlueprintName = "IMToolsTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "IMRxObservationTests"
+               BuildableName = "IMRxObservationTests"
+               BlueprintName = "IMRxObservationTests"
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>

--- a/Package.swift
+++ b/Package.swift
@@ -10,15 +10,19 @@ let package = Package(
     ],
     products: [
         .imrx,
+        .imrxObservation,
         .imTools,
     ],
     dependencies: [
         .combineSchedulers,
+        .concurrencyExtras,
         .customDump,
     ],
     targets: [
         .imrx,
         .imrxTests,
+        .imrxObservation,
+        .imrxObservationTests,
         .imTools,
         .imToolsTests,
     ]
@@ -32,7 +36,14 @@ private extension Product {
             .imrx
         ]
     )
-    
+
+    static let imrxObservation = library(
+        name: .imrxObservation,
+        targets: [
+            .imrxObservation
+        ]
+    )
+
     static let imTools = library(
         name: .imTools,
         targets: [
@@ -58,7 +69,22 @@ private extension Target {
             .imrx,
         ]
     )
-    
+
+    static let imrxObservation = target(
+        name: .imrxObservation,
+        dependencies: [],
+        exclude: ["ADR"]
+    )
+
+    static let imrxObservationTests = testTarget(
+        name: .imrxObservationTests,
+        dependencies: [
+            .concurrencyExtras,
+            .customDump,
+            .imrxObservation,
+        ]
+    )
+
     static let imTools = target(
         name: .imTools,
         dependencies: [
@@ -77,7 +103,9 @@ private extension Target {
 private extension Target.Dependency {
     
     static let imrx = byName(name: .imrx)
-    
+
+    static let imrxObservation = byName(name: .imrxObservation)
+
     static let imTools = byName(name: .imTools)
 }
 
@@ -85,7 +113,10 @@ private extension String {
     
     static let imrx = "IMRx"
     static let imrxTests = "IMRxTests"
-    
+
+    static let imrxObservation = "IMRxObservation"
+    static let imrxObservationTests = "IMRxObservationTests"
+
     static let imTools = "IMTools"
     static let imToolsTests = "IMToolsTests"
 }
@@ -100,6 +131,10 @@ private extension Package.Dependency {
     )
     static let combineSchedulers = Package.Dependency.package(
         url: .pointFreeGitHub + .combine_schedulers,
+        from: .init(1, 0, 0)
+    )
+    static let concurrencyExtras = Package.Dependency.package(
+        url: .pointFreeGitHub + .swift_concurrency_extras,
         from: .init(1, 0, 0)
     )
     static let customDump = Package.Dependency.package(
@@ -142,6 +177,10 @@ private extension Target.Dependency {
         name: .combineSchedulers,
         package: .combine_schedulers
     )
+    static let concurrencyExtras = product(
+        name: .concurrencyExtras,
+        package: .swift_concurrency_extras
+    )
     static let customDump = product(
         name: .customDump,
         package: .swift_custom_dump
@@ -181,6 +220,9 @@ private extension String {
     
     static let combineSchedulers = "CombineSchedulers"
     static let combine_schedulers = "combine-schedulers"
+
+    static let concurrencyExtras = "ConcurrencyExtras"
+    static let swift_concurrency_extras = "swift-concurrency-extras"
     
     static let customDump = "CustomDump"
     static let swift_custom_dump = "swift-custom-dump"

--- a/Sources/IMRxObservation/ADR/001-observable-model.md
+++ b/Sources/IMRxObservation/ADR/001-observable-model.md
@@ -1,0 +1,57 @@
+---
+date: 2026-04-07
+title: "ADR-001: ObservableModel — Observation-based reactive state machine"
+status: accepted
+---
+
+# ADR-001: ObservableModel — Observation-based reactive state machine
+
+## Context
+
+`RxViewModel` in `IMRx` uses Combine (`ObservableObject`, `@Published`, `PassthroughSubject`) and
+`CombineSchedulers` for serialized event processing. Porting it to Swift Observation requires
+fundamentally different machinery — the result is a new type, not a drop-in replacement.
+
+## Decision
+
+Introduce a **new module `IMRxObservation`** containing `ObservableModel<State, Event, Effect>`.
+
+### Key design choices
+
+| Aspect | `RxViewModel` (IMRx) | `ObservableModel` (IMRxObservation) |
+|---|---|---|
+| Reactivity | `ObservableObject` / `@Published` | `@Observable` macro |
+| Event serialization | `PassthroughSubject` + `receive(on: scheduler)` | `AsyncStream` + `for await` loop in a `Task` |
+| Effect handler signature | `(Effect, @escaping (Event) -> Void) -> Void` | `(Effect) -> AsyncStream<Event>` |
+| Scheduler control | `CombineSchedulers` (`AnySchedulerOf<DispatchQueue>`) | None — async runtime handles scheduling |
+| Test determinism | `.immediate` scheduler | `withMainSerialExecutor` from `swift-concurrency-extras` |
+| Sendability | Not `Sendable` | `@unchecked Sendable` |
+| Platform minimum | iOS 14 / macOS 11 | iOS 17 / macOS 14 (Observation framework) |
+
+### Why a new module (not replacing `RxViewModel`)
+
+- `@Observable` is not a drop-in for `ObservableObject` — consumers using `@ObservedObject`,
+  `@StateObject`, or `$state` (Combine publisher) would break.
+- Existing `IMRx` consumers can continue without changes.
+- Clean separation avoids conditional compilation and `#if` availability sprawl.
+
+### Why `@unchecked Sendable`
+
+- State writes are serialized through the `AsyncStream` consumer (single `Task`).
+- State reads are struct copies (value semantics).
+- `ObservationRegistrar` is internally synchronized.
+- `AsyncStream.Continuation` is `Sendable`.
+- No `@MainActor` isolation — the model is a general-purpose state machine, not tied to UI.
+
+### Why `AsyncStream<Event>` for effect handler
+
+- Supports multi-emit effects (e.g., cache hit followed by network update).
+- Natural fit for async/await — no callback-based dispatch.
+- Single-event effects simply yield once and finish.
+
+## Consequences
+
+- `IMRxObservation` has no dependency on `IMRx` or Combine.
+- Test dependency on `swift-concurrency-extras` for `withMainSerialExecutor`.
+- Existing `Reducer` and `EffectHandler` protocols from `IMRx` are not reused — the async
+  effect handler signature is incompatible. Closure-based typealiases are used instead.

--- a/Sources/IMRxObservation/ObservableModel.swift
+++ b/Sources/IMRxObservation/ObservableModel.swift
@@ -1,0 +1,101 @@
+//
+//  ObservableModel.swift
+//
+//
+//  Created by Igor Malyarov on 07.04.2026.
+//
+
+import Observation
+
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+@Observable
+public final class ObservableModel<State, Event, Effect>: @unchecked Sendable {
+
+    public private(set) var state: State
+
+    private let reduce: Reduce
+    private let handleEffect: HandleEffect
+    private let predicate: Predicate
+    private let continuation: AsyncStream<Event>.Continuation
+    private var task: Task<Void, Never>?
+
+    public init(
+        initialState: State,
+        reduce: @escaping Reduce,
+        handleEffect: @escaping HandleEffect,
+        predicate: @escaping Predicate = { _, _ in false }
+    ) {
+        self.state = initialState
+        self.reduce = reduce
+        self.handleEffect = handleEffect
+        self.predicate = predicate
+
+        let (stream, continuation) = AsyncStream.makeStream(of: Event.self)
+        self.continuation = continuation
+
+        self.task = Task { [weak self] in
+            for await event in stream {
+                guard let self else { return }
+                self.processEvent(event)
+            }
+        }
+    }
+
+    deinit {
+        task?.cancel()
+        continuation.finish()
+    }
+
+    private func processEvent(_ event: Event) {
+
+        let (newState, effect) = reduce(state, event)
+
+        if !predicate(state, newState) {
+            state = newState
+        }
+
+        if let effect {
+            let eventStream = handleEffect(effect)
+            let continuation = self.continuation
+            Task { [continuation] in
+                for await event in eventStream {
+                    continuation.yield(event)
+                }
+            }
+        }
+    }
+}
+
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+public extension ObservableModel {
+
+    func event(_ event: Event) {
+
+        continuation.yield(event)
+    }
+}
+
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+public extension ObservableModel {
+
+    typealias Reduce = (State, Event) -> (State, Effect?)
+    typealias HandleEffect = (Effect) -> AsyncStream<Event>
+    typealias Predicate = (State, State) -> Bool
+}
+
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+public extension ObservableModel where State: Equatable {
+
+    convenience init(
+        initialState: State,
+        reduce: @escaping Reduce,
+        handleEffect: @escaping HandleEffect
+    ) {
+        self.init(
+            initialState: initialState,
+            reduce: reduce,
+            handleEffect: handleEffect,
+            predicate: ==
+        )
+    }
+}

--- a/Tests/IMRxObservationTests/Helpers/AsyncEffectHandlerSpy.swift
+++ b/Tests/IMRxObservationTests/Helpers/AsyncEffectHandlerSpy.swift
@@ -1,0 +1,37 @@
+//
+//  AsyncEffectHandlerSpy.swift
+//
+
+final class AsyncEffectHandlerSpy<Event, Effect>
+where Event: Equatable,
+      Effect: Equatable {
+
+    private(set) var effects = [Effect]()
+    private var continuations = [AsyncStream<Event>.Continuation]()
+
+    var callCount: Int { effects.count }
+
+    func handleEffect(_ effect: Effect) -> AsyncStream<Event> {
+
+        effects.append(effect)
+        let (stream, continuation) = AsyncStream.makeStream(of: Event.self)
+        continuations.append(continuation)
+        return stream
+    }
+
+    func complete(with event: Event, at index: Int = 0) {
+
+        continuations[index].yield(event)
+        continuations[index].finish()
+    }
+
+    func yield(_ event: Event, at index: Int = 0) {
+
+        continuations[index].yield(event)
+    }
+
+    func finish(at index: Int = 0) {
+
+        continuations[index].finish()
+    }
+}

--- a/Tests/IMRxObservationTests/Helpers/ReducerSpy.swift
+++ b/Tests/IMRxObservationTests/Helpers/ReducerSpy.swift
@@ -1,0 +1,30 @@
+//
+//  ReducerSpy.swift
+//
+
+final class ReducerSpy<State, Event, Effect>
+where State: Equatable,
+      Event: Equatable,
+      Effect: Equatable {
+
+    private var stub: [(State, Effect?)]
+    private(set) var messages = [Message]()
+
+    var callCount: Int { messages.count }
+
+    init(stub: [(State, Effect?)]) {
+
+        self.stub = stub
+    }
+
+    func reduce(
+        _ state: State,
+        _ event: Event
+    ) -> (State, Effect?) {
+
+        messages.append((state, event))
+        return stub.removeFirst()
+    }
+
+    typealias Message = (state: State, event: Event)
+}

--- a/Tests/IMRxObservationTests/Helpers/XCTAssertNoDiff.swift
+++ b/Tests/IMRxObservationTests/Helpers/XCTAssertNoDiff.swift
@@ -1,0 +1,37 @@
+//
+//  XCTAssertNoDiff.swift
+//
+
+import CustomDump
+import XCTest
+
+func XCTAssertNoDiff<T>(
+    _ expression1: @autoclosure () throws -> T,
+    _ expression2: @autoclosure () throws -> T,
+    _ message: @autoclosure () -> String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line
+) where T: Equatable {
+
+    do {
+        let expression1 = try expression1()
+        let expression2 = try expression2()
+        let message = message()
+
+        XCTAssertNoDifference(
+            expression1,
+            expression2,
+            message,
+            file: file,
+            line: line
+        )
+    } catch {
+        XCTFail(
+                """
+                Assert failed with error "\(error)"
+                """,
+                file: file,
+                line: line
+        )
+    }
+}

--- a/Tests/IMRxObservationTests/Helpers/XCTestCase+MemoryLeakTracking.swift
+++ b/Tests/IMRxObservationTests/Helpers/XCTestCase+MemoryLeakTracking.swift
@@ -1,0 +1,24 @@
+//
+//  XCTestCase+MemoryLeakTracking.swift
+//
+
+import XCTest
+
+extension XCTestCase {
+
+    func trackForMemoryLeaks(
+        _ instance: AnyObject,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        addTeardownBlock { [weak instance] in
+
+            XCTAssertNil(
+                instance,
+                "Instance should have been deallocated. Potential memory leak.",
+                file: file,
+                line: line
+            )
+        }
+    }
+}

--- a/Tests/IMRxObservationTests/Helpers/anyMessage.swift
+++ b/Tests/IMRxObservationTests/Helpers/anyMessage.swift
@@ -1,0 +1,10 @@
+//
+//  anyMessage.swift
+//
+
+import Foundation
+
+func anyMessage() -> String {
+
+    UUID().uuidString
+}

--- a/Tests/IMRxObservationTests/ObservableModelTests.swift
+++ b/Tests/IMRxObservationTests/ObservableModelTests.swift
@@ -1,0 +1,313 @@
+//
+//  ObservableModelTests.swift
+//
+//
+//  Created by Igor Malyarov on 07.04.2026.
+//
+
+import ConcurrencyExtras
+import IMRxObservation
+import XCTest
+
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+final class ObservableModelTests: XCTestCase {
+
+    func test_init_shouldNotCallCollaborators() async {
+
+        await withMainSerialExecutor {
+            let (_, reducer, effectHandler) = makeSUT()
+
+            XCTAssertNoDiff(reducer.callCount, 0)
+            XCTAssertNoDiff(effectHandler.callCount, 0)
+        }
+    }
+
+    func test_event_shouldCallReducerWithGivenStateAndEvent() async {
+
+        await withMainSerialExecutor {
+            let initialState = makeState()
+            let event: Event = .resetValue
+            let (sut, reducer, _) = makeSUT(
+                initialState: initialState,
+                stub: makeStub()
+            )
+
+            sut.event(event)
+            await settle()
+
+            XCTAssertNoDiff(reducer.messages.map(\.state), [initialState])
+            XCTAssertNoDiff(reducer.messages.map(\.event), [event])
+        }
+    }
+
+    func test_event_shouldNotCallEffectHandlerOnNilEffect() async {
+
+        await withMainSerialExecutor {
+            let effect: Effect? = nil
+            let (sut, _, effectHandler) = makeSUT(
+                stub: makeStub(effect)
+            )
+
+            sut.event(.resetValue)
+            await settle()
+
+            XCTAssertNoDiff(effectHandler.callCount, 0)
+        }
+    }
+
+    func test_event_shouldCallEffectHandlerOnNonNilEffect() async {
+
+        await withMainSerialExecutor {
+            let effect: Effect = .load
+            let (sut, _, effectHandler) = makeSUT(
+                stub: makeStub(effect)
+            )
+
+            sut.event(.resetValue)
+            await settle()
+
+            XCTAssertNoDiff(effectHandler.effects, [effect])
+        }
+    }
+
+    func test_event_shouldCallReducerTwiceOnEffect() async {
+
+        await withMainSerialExecutor {
+            let (sut, reducer, effectHandler) = makeSUT(
+                initialState: makeState(),
+                stub: makeStub(.load), makeStub()
+            )
+
+            sut.event(.resetValue)
+            await settle()
+
+            let value = UUID().uuidString
+            effectHandler.complete(with: .changeValueTo(value))
+            await settle()
+
+            XCTAssertNoDiff(reducer.callCount, 2)
+        }
+    }
+
+    func test_event_shouldReduceWithGivenStateAndEvent() async {
+
+        await withMainSerialExecutor {
+            let initialState = makeState()
+            let first = makeStub(.load)
+            let last = makeStub()
+            let (sut, reducer, effectHandler) = makeSUT(
+                initialState: initialState,
+                stub: first, last
+            )
+
+            sut.event(.resetValue)
+            await settle()
+
+            let value = UUID().uuidString
+            effectHandler.complete(with: .changeValueTo(value))
+            await settle()
+
+            XCTAssertNoDiff(reducer.messages.map(\.state), [
+                initialState,
+                first.0,
+            ])
+            XCTAssertNoDiff(reducer.messages.map(\.event), [
+                .resetValue,
+                .changeValueTo(value),
+            ])
+        }
+    }
+
+    func test_event_shouldDeliverStateValues() async {
+
+        await withMainSerialExecutor {
+            let initialState = makeState()
+            let first = makeStub(.load)
+            let last = makeStub()
+            let (sut, _, effectHandler) = makeSUT(
+                initialState: initialState,
+                stub: first, last
+            )
+
+            XCTAssertNoDiff(sut.state, initialState)
+
+            sut.event(.resetValue)
+            await settle()
+
+            XCTAssertNoDiff(sut.state, first.0)
+
+            let value = UUID().uuidString
+            effectHandler.complete(with: .changeValueTo(value))
+            await settle()
+
+            XCTAssertNoDiff(sut.state, last.0)
+        }
+    }
+
+    func test_event_shouldUpdateStateOnSuccessiveEvents() async {
+
+        await withMainSerialExecutor {
+            let (sut, _, _) = makeSUT(
+                initialState: .init(value: ""),
+                stub: (State(value: "a"), nil),
+                      (State(value: "ab"), nil)
+            )
+
+            sut.event(.resetValue)
+            sut.event(.resetValue)
+            await settle()
+
+            XCTAssertNoDiff(sut.state, State(value: "ab"))
+        }
+    }
+
+    func test_event_shouldUsePredicateToSkipStateUpdate() async {
+
+        await withMainSerialExecutor {
+            let newState = makeState()
+            let (sut, _, _) = makeSUT(
+                stub: (newState, nil),
+                predicate: { _, _ in true }
+            )
+            let initialState = sut.state
+
+            sut.event(.resetValue)
+            await settle()
+
+            XCTAssertNoDiff(sut.state, initialState, "Expected state unchanged due to predicate.")
+        }
+    }
+
+    func test_event_shouldUsePredicateToAllowStateUpdate() async {
+
+        await withMainSerialExecutor {
+            let newState = makeState()
+            let (sut, _, _) = makeSUT(
+                stub: (newState, nil),
+                predicate: { _, _ in false }
+            )
+
+            sut.event(.resetValue)
+            await settle()
+
+            XCTAssertNoDiff(sut.state, newState)
+        }
+    }
+
+    func test_shouldNotDeliverEffectEventsOnInstanceDeallocation() async {
+
+        await withMainSerialExecutor {
+            var sut: SUT?
+            let effectHandler: EffectHandleSpy
+            let reducer: ReduceSpy
+            (sut, reducer, effectHandler) = makeSUT(
+                stub: makeStub(.load), makeStub()
+            )
+
+            sut?.event(.resetValue)
+            await settle()
+
+            let stateBeforeDealloc = sut?.state
+            sut = nil
+            effectHandler.complete(with: .changeValueTo(anyMessage()))
+            await settle()
+
+            XCTAssertNoDiff(reducer.callCount, 1, "No further events should be processed after deallocation")
+            _ = stateBeforeDealloc
+        }
+    }
+
+    func test_effectHandler_shouldEmitMultipleEvents() async {
+
+        await withMainSerialExecutor {
+            let first = makeState()
+            let second = makeState()
+            let third = makeState()
+            let (sut, reducer, effectHandler) = makeSUT(
+                stub: (first, .load),
+                      (second, nil),
+                      (third, nil)
+            )
+
+            sut.event(.resetValue)
+            await settle()
+
+            effectHandler.yield(.resetValue)
+            await settle()
+
+            effectHandler.complete(with: .resetValue)
+            await settle()
+
+            XCTAssertNoDiff(reducer.callCount, 3)
+            XCTAssertNoDiff(sut.state, third)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private typealias SUT = ObservableModel<State, Event, Effect>
+    private typealias ReduceSpy = ReducerSpy<State, Event, Effect>
+    private typealias EffectHandleSpy = AsyncEffectHandlerSpy<Event, Effect>
+
+    private func makeSUT(
+        initialState: State = makeState(),
+        stub: (State, Effect?)...,
+        predicate: @escaping (State, State) -> Bool = { _, _ in false },
+        file: StaticString = #file,
+        line: UInt = #line
+    ) -> (
+        sut: SUT,
+        reducer: ReduceSpy,
+        effectHandler: EffectHandleSpy
+    ) {
+        let reducer = ReduceSpy(stub: stub)
+        let effectHandler = EffectHandleSpy()
+        let sut = SUT(
+            initialState: initialState,
+            reduce: reducer.reduce,
+            handleEffect: effectHandler.handleEffect,
+            predicate: predicate
+        )
+
+        trackForMemoryLeaks(sut, file: file, line: line)
+        trackForMemoryLeaks(reducer, file: file, line: line)
+        trackForMemoryLeaks(effectHandler, file: file, line: line)
+
+        return (sut, reducer, effectHandler)
+    }
+
+    fileprivate struct State: Equatable {
+
+        let value: String
+    }
+
+    private enum Event: Equatable {
+
+        case changeValueTo(String)
+        case resetValue
+    }
+
+    private enum Effect: Equatable {
+
+        case load
+    }
+
+    private func makeStub(
+        _ effect: Effect? = nil
+    ) -> (State, Effect?) {
+
+        (makeState(), effect)
+    }
+
+    private func settle() async {
+
+        await Task.megaYield()
+    }
+}
+
+private func makeState(
+    value: String = UUID().uuidString
+) -> ObservableModelTests.State {
+
+    .init(value: value)
+}


### PR DESCRIPTION
## Summary
- New `IMRxObservation` module with `ObservableModel<State, Event, Effect>` — an `@Observable`, `@unchecked Sendable` state machine using `AsyncStream`-based event serialization
- Async effect handler signature `(Effect) -> AsyncStream<Event>` supporting multi-emit effects
- ADR documenting design decisions (why new module, why `@unchecked Sendable`, why `AsyncStream`)
- 12 tests using `withMainSerialExecutor` + `Task.megaYield()` from `swift-concurrency-extras`
- Xcode schemes and test plans updated

## Test plan
- [x] All 43 tests pass (`swift test`) — 12 new + 31 existing
- [ ] Verify Xcode schemes build and test correctly